### PR TITLE
Add library support

### DIFF
--- a/plugin/src/main/groovy/com/sensorsdata/analytics/android/plugin/SensorsAnalyticsPlugin.groovy
+++ b/plugin/src/main/groovy/com/sensorsdata/analytics/android/plugin/SensorsAnalyticsPlugin.groovy
@@ -17,6 +17,8 @@
 package com.sensorsdata.analytics.android.plugin
 
 import com.android.build.gradle.AppExtension
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.LibraryExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.internal.reflect.Instantiator
@@ -43,12 +45,13 @@ class SensorsAnalyticsPlugin implements Plugin<Project> {
             isHookOnMethodEnter = Boolean.parseBoolean(properties.getProperty("sensorsAnalytics.isHookOnMethodEnter", "false"))
         }
         if (!disableSensorsAnalyticsPlugin) {
-            AppExtension appExtension = project.extensions.findByType(AppExtension.class)
+            boolean hasLibraryPlugin = project.plugins.hasPlugin("com.android.library")
+            BaseExtension baseExtension = project.extensions.findByType(hasLibraryPlugin ? LibraryExtension.class : AppExtension.class)
             SensorsAnalyticsTransformHelper transformHelper = new SensorsAnalyticsTransformHelper(extension, appExtension)
             transformHelper.disableSensorsAnalyticsIncremental = disableSensorsAnalyticsIncrementalBuild
             transformHelper.disableSensorsAnalyticsMultiThread = disableSensorsAnalyticsMultiThreadBuild
             transformHelper.isHookOnMethodEnter = isHookOnMethodEnter
-            appExtension.registerTransform(new SensorsAnalyticsTransform(transformHelper))
+            baseExtension.registerTransform(new SensorsAnalyticsTransform(transformHelper, hasLibraryPlugin))
             project.afterEvaluate {
                 Logger.setDebug(extension.debug)
             }

--- a/plugin/src/main/groovy/com/sensorsdata/analytics/android/plugin/SensorsAnalyticsPlugin.groovy
+++ b/plugin/src/main/groovy/com/sensorsdata/analytics/android/plugin/SensorsAnalyticsPlugin.groovy
@@ -47,7 +47,7 @@ class SensorsAnalyticsPlugin implements Plugin<Project> {
         if (!disableSensorsAnalyticsPlugin) {
             boolean hasLibraryPlugin = project.plugins.hasPlugin("com.android.library")
             BaseExtension baseExtension = project.extensions.findByType(hasLibraryPlugin ? LibraryExtension.class : AppExtension.class)
-            SensorsAnalyticsTransformHelper transformHelper = new SensorsAnalyticsTransformHelper(extension, appExtension)
+            SensorsAnalyticsTransformHelper transformHelper = new SensorsAnalyticsTransformHelper(extension, baseExtension)
             transformHelper.disableSensorsAnalyticsIncremental = disableSensorsAnalyticsIncrementalBuild
             transformHelper.disableSensorsAnalyticsMultiThread = disableSensorsAnalyticsMultiThreadBuild
             transformHelper.isHookOnMethodEnter = isHookOnMethodEnter

--- a/plugin/src/main/groovy/com/sensorsdata/analytics/android/plugin/SensorsAnalyticsTransform.groovy
+++ b/plugin/src/main/groovy/com/sensorsdata/analytics/android/plugin/SensorsAnalyticsTransform.groovy
@@ -49,9 +49,11 @@ class SensorsAnalyticsTransform extends Transform {
     public static final String MIN_SDK_VERSION = "4.0.7"
     private WaitableExecutor waitableExecutor
     private URLClassLoader urlClassLoader
+    private boolean hasLibraryPlugin = false
 
-    SensorsAnalyticsTransform(SensorsAnalyticsTransformHelper transformHelper) {
+    SensorsAnalyticsTransform(SensorsAnalyticsTransformHelper transformHelper, boolean hasLibraryPlugin) {
         this.transformHelper = transformHelper
+        this.hasLibraryPlugin = hasLibraryPlugin
         if (!transformHelper.disableSensorsAnalyticsMultiThread) {
             waitableExecutor = WaitableExecutor.useGlobalSharedThreadPool()
         }
@@ -69,7 +71,7 @@ class SensorsAnalyticsTransform extends Transform {
 
     @Override
     Set<QualifiedContent.Scope> getScopes() {
-        return TransformManager.SCOPE_FULL_PROJECT
+        return hasLibraryPlugin ? TransformManager.PROJECT_ONLY : TransformManager.SCOPE_FULL_PROJECT
     }
 
     @Override


### PR DESCRIPTION
Cause library do not support Transform Scope.SUB_PROJECTS and Scope.EXTERNAL_LIBRARIES, so if the plugin apply to library then just cover the Scope.PROJECT